### PR TITLE
Cover case of a failed checkout

### DIFF
--- a/download_data.py
+++ b/download_data.py
@@ -111,8 +111,17 @@ def move_files(temp_dir, dataset_dir):
 
     for i, repo_data in enumerate(snapshot_data):
         new_repo_id = hashlib.sha256(repo_data["id"].encode()).hexdigest()[:8]
-
+        repo_url = repo_data["url"]
+        ownername, reponame = repo_url.split("/")[-2:]
         meta_file_path = f"meta/{new_repo_id}.csv"
+
+        if is_empty(f"{temp_dir}/{ownername}/{reponame}"):
+            print(f"Couldn't find data in {new_repo_id} repo. "
+                  f"Removing {meta_file_path}, so missing files would not count in the dataset statistics")
+            print(f"You can use git to restore {meta_file_path} file back")
+            if os.path.exists(meta_file_path):
+                os.remove(meta_file_path)
+            continue
 
         # Select file names from meta that we will use in dataset
         interesting_files = set()
@@ -120,16 +129,6 @@ def move_files(temp_dir, dataset_dir):
             meta_reader = csv.DictReader(csvfile)
             for row in meta_reader:
                 interesting_files.add(row["FileID"])
-
-        repo_url = repo_data["url"]
-        ownername, reponame = repo_url.split("/")[-2:]
-
-        if is_empty(f"{temp_dir}/{ownername}/{reponame}"):
-            print(f"Couldn't find data in {new_repo_id} repo. "
-                  f"Removing {meta_file_path}, so missing files would not count in the dataset statistics")
-            print(f"You can use git to restore {meta_file_path} file back")
-            os.remove(meta_file_path)
-            continue
 
         # Select all files in the repo
         # pathlib.Path.glob used instead of glob.glob, as glob.glob could not search for a hidden files

--- a/download_data.py
+++ b/download_data.py
@@ -108,6 +108,7 @@ def move_files(temp_dir, dataset_dir):
     os.makedirs(temp_dir, exist_ok=True)
 
     os.makedirs(dataset_dir, exist_ok=True)
+    missing_repos = []
 
     for i, repo_data in enumerate(snapshot_data):
         new_repo_id = hashlib.sha256(repo_data["id"].encode()).hexdigest()[:8]
@@ -115,12 +116,11 @@ def move_files(temp_dir, dataset_dir):
         ownername, reponame = repo_url.split("/")[-2:]
         meta_file_path = f"meta/{new_repo_id}.csv"
 
-        if is_empty(f"{temp_dir}/{ownername}/{reponame}"):
-            print(f"Couldn't find data in {new_repo_id} repo. "
+        if not os.path.exists(meta_file_path):
+            print(f"Couldn't find all files mentioned in metadata. in {new_repo_id} repo. "
                   f"Removing {meta_file_path}, so missing files would not count in the dataset statistics")
             print(f"You can use git to restore {meta_file_path} file back")
-            if os.path.exists(meta_file_path):
-                os.remove(meta_file_path)
+            missing_repos.append(meta_file_path)
             continue
 
         # Select file names from meta that we will use in dataset
@@ -146,8 +146,13 @@ def move_files(temp_dir, dataset_dir):
                 ids_found.add(file_id)
 
         # Check if there are files that present in meta but we could not find, or we somehow found files not from meta
-        assert len(ids_found.symmetric_difference(interesting_files)) == 0, \
-            "Could not find all files mentioned in metadata. Try to remove `tmp` directory and run again."
+        if len(ids_found.symmetric_difference(interesting_files)) != 0:
+            print(f"Couldn't find all files mentioned in metadata. in {new_repo_id} repo. "
+                  f"Removing {meta_file_path}, so missing files would not count in the dataset statistics")
+            print(f"You can use git to restore {meta_file_path} file back")
+            missing_repos.append(meta_file_path)
+            if os.path.exists(meta_file_path):
+                os.remove(meta_file_path)
 
         # Copy files to new dataset location
         for j, full_path in enumerate(sorted(list(files_found))):
@@ -170,6 +175,8 @@ def move_files(temp_dir, dataset_dir):
                 shutil.copy(license_location, f"{dataset_dir}/{new_repo_id}/{name}")
 
         print(f"Processed: {i + 1}/{len(snapshot_data)}")
+
+    return missing_repos
 
 
 def get_obfuscated_value(value, predefined_pattern):
@@ -462,8 +469,15 @@ if __name__ == "__main__":
     print("Start download")
     download(temp_directory)
     print("Download finished. Now processing the files...")
-    move_files(temp_directory, args.data_dir)
+    removed_meta = move_files(temp_directory, args.data_dir)
     print("Finalizing dataset. Please wait a moment...")
     obfuscate_creds(args.data_dir)
     print("Done!")
     print(f"All files saved to {args.data_dir}")
+
+    if len(removed_meta) > 0:
+        print("Some repos had a problem with download.")
+        print("Removing meta so missing files would not count in the dataset statistics:")
+        for missing in removed_meta:
+            print(missing)
+        print(f"You can use git to restore mentioned meta files back")

--- a/download_data.py
+++ b/download_data.py
@@ -117,7 +117,7 @@ def move_files(temp_dir, dataset_dir):
         meta_file_path = f"meta/{new_repo_id}.csv"
 
         if not os.path.exists(meta_file_path):
-            print(f"Couldn't find all files mentioned in metadata. in {new_repo_id} repo. "
+            print(f"Couldn't find all files mentioned in metadata for {new_repo_id} repo. "
                   f"Removing {meta_file_path}, so missing files would not count in the dataset statistics")
             print(f"You can use git to restore {meta_file_path} file back")
             missing_repos.append(meta_file_path)
@@ -147,7 +147,7 @@ def move_files(temp_dir, dataset_dir):
 
         # Check if there are files that present in meta but we could not find, or we somehow found files not from meta
         if len(ids_found.symmetric_difference(interesting_files)) != 0:
-            print(f"Couldn't find all files mentioned in metadata. in {new_repo_id} repo. "
+            print(f"Couldn't find all files mentioned in metadata for {new_repo_id} repo. "
                   f"Removing {meta_file_path}, so missing files would not count in the dataset statistics")
             print(f"You can use git to restore {meta_file_path} file back")
             missing_repos.append(meta_file_path)


### PR DESCRIPTION
Fix case where repo might gone private, or commit removed from the history

- if `move_files` encountered empty repo directory, this directory would be skipped with a message
related meta file would be removed, so mismatch between meta and real files would not have an affect later on
- if checkout process failed - repo will be removed, so `move_files` would also skip it